### PR TITLE
Docs: align init/compile examples with CLI default path change

### DIFF
--- a/documentation/getting-started/installation.mdx
+++ b/documentation/getting-started/installation.mdx
@@ -50,9 +50,10 @@ icon: 'download'
   </Step>
   <Step title="Setup">
     Setup a new project using the following command
-    ```bash
-    helix init --path helixdb-cfg
-    ```
+		```bash
+		helix init --path helixdb-cfg
+		cd helixdb-cfg
+		```
   </Step>
   <Step title="Write Schema and Queries">
     Write your schema and queries in the newly created `.hx` files.

--- a/documentation/getting-started/quick-start.mdx
+++ b/documentation/getting-started/quick-start.mdx
@@ -51,9 +51,10 @@ mode: "wide"
   <Step title="Setup">
     ### Setup a new project
     Setup a new project using the following command
-    ```bash
-    helix init --path helixdb-cfg
-    ```
+		```bash
+		helix init --path helixdb-cfg
+		cd helixdb-cfg
+		```
 
     ### Setup Your SDK
     <CodeGroup>

--- a/guides/helixir.mdx
+++ b/guides/helixir.mdx
@@ -48,6 +48,7 @@ Setup a new project using the following command:
 
 ```bash
 helix init --path helixdb-cfg
+cd helixdb-cfg
 ```
 
 Great, now you might have noticed that a helixdb-cfg folder appeared. In there you will start writing the schema for this tutorial.


### PR DESCRIPTION
This PR updates the documentation to stay compatible with the CLI changes introduced in [#375](https://github.com/HelixDB/helix-db/pull/375).