### PR TITLE
Docs: fix formatting of check and deploy examples

### DIFF
--- a/documentation/getting-started/quick-start.mdx
+++ b/documentation/getting-started/quick-start.mdx
@@ -283,7 +283,10 @@ mode: "wide"
   </Step>
 
 <Step title="Check Your Schema and Queries">
-  Using the following command ```bash helix check ```
+  Using the following command
+	 ```bash
+	 helix check
+	 ```
   <Check>
     If you see "Helix-QL schema and queries validated successfully with zero
     errors", you are ready to deploy your instance!
@@ -291,7 +294,10 @@ mode: "wide"
 </Step>
 
 <Step title="Deploy Instance">
-  Using the following command ```bash helix deploy ```
+  Using the following command
+	 ```bash
+	 helix deploy
+	 ```
   <Check>
     If you see "Successfully started Helix instance", you are ready to run
     queries!


### PR DESCRIPTION
Fixed the formatting of `helix check` and `helix deploy` examples in the 
Quick Start guide so they render as proper code blocks in Mintlify.

### Before
<img width="513" height="193" alt="image" src="https://github.com/user-attachments/assets/b7310cc4-6122-49b7-864f-854afbd95212" />

### After
<img width="624" height="284" alt="image" src="https://github.com/user-attachments/assets/32276fac-1923-4d79-8ca6-af2098c2558f" />
