### PR TITLE
Update Python SDK Docs

### DIFF
--- a/documentation/sdks/helix-py.mdx
+++ b/documentation/sdks/helix-py.mdx
@@ -9,8 +9,6 @@ a powerful graph-vector database written in Rust. It provides both a simple quer
 front-end for defining and executing custom graph queries and vector-based operations. This makes it
 well-suited for use cases such as similarity search, knowledge graph construction, and machine learning pipelines.
 
-> helix-py is evolving into a full-fledged knowledge graph framework. Expect major updates in version v0.3.0.
-
 ## Installation
 
 <CodeGroup>
@@ -56,6 +54,8 @@ class add_user(Query):
     def response(self, response):
         return response
 ```
+
+Make sure that the `Query.query` method returns a list of objects.
 
 ## Client
 To setup a simple `Client` to interface with a running helix instance:
@@ -118,20 +118,109 @@ and from there you can interact with the instance using `Client`.
 The instance will be automatically stopped when the script exits.
 
 ## Providers
-We also provide an Ollama and OpenAI interface. This will be expanded to include many other providers in the future.
-```python Python
-from helix.providers import OllamaClient, OpenAIClient
-ollama_client = OllamaClient(use_history=True, model="mistral:latest")
-openai_client = OpenAIClient(use_history=True, model="gpt-4o")
+Helix has LLM interfaces for popular LLM providers. 
 
-while True:
-    prompt = input(">>> ")
-    res = ollama_client.request(prompt, stream=True)
+**Available providers**:
+- `OpenAIProvider`
+- `GeminiProvider`
+- `AnthropicProvider`
+
+<Warning>
+Don't forget to set the `OPENAI_API_KEY`, `GEMINI_API_KEY`, and `ANTHROPIC_API_KEY` environment variables depending on the provider you are using.
+</Warning>
+
+All providers expose two methods:
+- `enable_mcps(name: str, url: str=...) -> bool` to enable Helix MCP tools
+- `generate(messages, response_model: BaseModel | None=None) -> str | BaseModel`
+
+The generate method supports messages in the 2 formats:
+- **Free-form text**: pass a string
+- **Message lists**: pass a list of `dict` or provider-specific `Message` models
+
+It also supports structured outputs by passing a Pydantic model to get validated results.
+
+**Example:**
+```python
+from pydantic import BaseModel
+
+# OpenAI
+from helix.providers.openai_client import OpenAIProvider
+openai_llm = OpenAIProvider(
+    name="openai-llm",
+    instructions="You are a helpful assistant.",
+    model="gpt-5-nano",
+    history=True
+)
+print(openai_llm.generate("Hello!"))
+
+class Person(BaseModel):
+    name: str
+    age: int
+    occupation: str
+
+print(openai_llm.generate([{"role": "user", "content": "Who am I?"}], Person))
+```
+
+To enable MCP tools with a running Helix MCP server (see [MCP Feature](../../features/mcp/helix-mcp)):
+```python
+openai_llm.enable_mcps("helix-mcp")         # uses default http://localhost:8000/mcp/
+gemini_llm.enable_mcps("helix-mcp")         # uses default http://localhost:8000/mcp/
+anthropic_llm.enable_mcps("helix-mcp", url="https://your-remote-mcp/...")
 ```
 
 <Note>
-    To use the OpenAi client, you must either pass in your OpenAI API key as `api_key` or set the `OPENAI_API_KEY` environment variable.
+- OpenAI GPT-5 family models support reasoning while other models use temperature.
+- Anthropic local streamable MCP is not supported; use a URL-based MCP.
 </Note>
+
+## Embedders
+Helix has embedder interfaces for popular embedding providers.
+
+Available embedders:
+- `OpenAIEmbedder`
+- `GeminiEmbedder`
+- `VoyageAIEmbedder`
+
+Each embedder implements:
+- `embed(text: str, **kwargs)` returns a vector `[F64]`
+- `embed_batch(texts: List[str], **kwargs)` returns a list of vectors `[F64]`
+
+Examples (see `examples/llm_providers/providers.ipynb` for more):
+```python
+from helix.embedding.openai_client import OpenAIEmbedder
+openai_embedder = OpenAIEmbedder()  # requires OPENAI_API_KEY
+vec = openai_embedder.embed("Hello world")
+batch = openai_embedder.embed_batch(["a", "b", "c"])
+
+from helix.embedding.gemini_client import GeminiEmbedder
+gemini_embedder = GeminiEmbedder()
+vec = gemini_embedder.embed("doc text", task_type="RETRIEVAL_DOCUMENT")
+
+from helix.embedding.voyageai_client import VoyageAIEmbedder
+voyage_embedder = VoyageAIEmbedder()
+vec = voyage_embedder.embed("query text", input_type="query")
+```
+
+## Chunking
+
+Helix uses [Chonkie](https://chonkie.ai/) chunking methods to split text into manageable pieces for processing and embedding:
+
+```python
+from helix import Chunk
+
+text = "Your long document text here..."
+chunks = Chunk.token_chunk(text)
+
+semantic_chunks = Chunk.semantic_chunk(text)
+
+code_text = "def hello(): print('world')"
+code_chunks = Chunk.code_chunk(code_text, language="python")
+
+texts = ["Document 1...", "Document 2...", "Document 3..."]
+batch_chunks = Chunk.sentence_chunk(texts)
+```
+
+You can find all the different chunking examples inside of [Chunking Feature](../../features/chunking/helix-chunking).
 
 ## Loader
 The loader (`helix/loader.py`) currently supports `.parquet`, `.fvecs`, and `.csv` data. Simply pass in the path to your


### PR DESCRIPTION
This pull request updates the Helix Python SDK documentation to clarify usage and expand coverage of available providers, embedders, and chunking features. The most important changes are the addition of detailed sections for LLM providers, embedders, and chunking, as well as improved guidance on API usage and environment configuration.

### LLM Provider
* Expanded documentation for LLM provider interfaces, listing `OpenAIProvider`, `GeminiProvider`, and `AnthropicProvider`, with instructions on enabling MCP tools and using structured outputs with Pydantic models. Also added a warning to set the necessary API keys for each provider.
* Removed outdated example code for Ollama and OpenAI clients, replacing it with new usage examples for the updated provider classes.

### Embedder Interfaces
* Added a new section detailing supported embedders (`OpenAIEmbedder`, `GeminiEmbedder`, `VoyageAIEmbedder`), with example code for embedding single texts and batches, and notes on environment variables.

### Chunking Functionality
* Introduced documentation for chunking methods using the `Chunk` class, with examples for token, semantic, code, and sentence chunking, and a link to additional chunking feature documentation.