### PR TITLE
Fix all edge From To order

### DIFF
--- a/documentation/getting-started/helixdb.mdx
+++ b/documentation/getting-started/helixdb.mdx
@@ -36,8 +36,8 @@ HelixDB follows the property graph model, which consists of:
 - **Edges**: Represent relationships between nodes and/or vectors, with directionality and properties
   ```js
   E::EdgeType {
-    To: String,
     From: String,
+    To: String,
     Properties: {
       field1: String,
       field2: U32

--- a/documentation/infra/schema/schema-definition.mdx
+++ b/documentation/infra/schema/schema-definition.mdx
@@ -27,8 +27,8 @@ Defines relationships between nodes and their properties.
 
 ```rust
 E::EdgeType {
-  To: String,
   From: String,
+  To: String,
   Properties: {
     field1: String,
     field2: U32


### PR DESCRIPTION
This pull request makes a minor but important correction to the documentation for the property graph model and schema definition examples. The order of the `From` and `To` fields in the `E::EdgeType` examples has been updated for consistency and clarity.

- Documentation consistency:
  * In both `documentation/getting-started/helixdb.mdx` and `documentation/infra/schema/schema-definition.mdx`, the `E::EdgeType` example now lists the `From` field before the `To` field, matching standard conventions and improving readability.